### PR TITLE
Set inactive state to table when data is loading. Move spinner inside the table

### DIFF
--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -1,7 +1,11 @@
 <template>
   <div id="dataTable">
     <slot name="filter" />
-    <div class="dataTable">
+    <div
+      :style="{overflow: hiddenIfLoading}"
+      class="dataTable"
+    >
+
       <slot
         name="quickFilter"
       />
@@ -12,6 +16,15 @@
       >
         Items in table: {{ rows }}
       </h6>
+
+      <b-progress
+        :value="100"
+        :animated="true"
+        v-if="loading"
+        variant="secondary"
+        class="mt-1"
+        height="7px"
+      />
       <b-table
         :busy="loading"
         :small="small"
@@ -20,24 +33,11 @@
         :striped="striped"
         :fixed="fixed"
         :fields="fields"
+        class="datatable-content"
         show-empty
         sticky-header="calc(100vh - 12rem)"
         hover
       >
-        <template
-          v-slot:table-busy
-        >
-          <div
-            class="text-left my-2"
-          >
-            <b-spinner
-              class="align-middle"
-            />
-            <strong>
-              Loading...
-            </strong>
-          </div>
-        </template>
 
         <template
           v-slot:empty="scope">
@@ -123,6 +123,9 @@ export default {
     onlyOnePage() {
       return false;
     },
+    hiddenIfLoading() {
+      return this.loading ? 'hidden' : 'visible';
+    },
   },
 };
 </script>
@@ -138,6 +141,11 @@ export default {
     position: absolute;
     top: 0.5rem;
     right: 15px;
+  }
+
+  .datatable-content {
+    display: table;
+    min-width: 100%;
   }
 
   .pagination {

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -2,13 +2,7 @@
   <div id="dataTable">
     <slot name="filter" />
     <div class="dataTable">
-      <b-spinner
-        v-if="loading"
-        variant="primary"
-        label="Spinning"
-      />
       <slot
-        v-if="!loading"
         name="quickFilter"
       />
 
@@ -19,16 +13,42 @@
         Items in table: {{ rows }}
       </h6>
       <b-table
-        v-if="!loading"
+        :busy="loading"
         :small="small"
         :items="items"
         :per-page="perPage"
         :striped="striped"
         :fixed="fixed"
         :fields="fields"
+        show-empty
         sticky-header="calc(100vh - 12rem)"
         hover
       >
+        <template
+          v-slot:table-busy
+        >
+          <div
+            class="text-left my-2"
+          >
+            <b-spinner
+              class="align-middle"
+            />
+            <strong>
+              Loading...
+            </strong>
+          </div>
+        </template>
+
+        <template
+          v-slot:empty="scope">
+          <div
+            class="text-left"
+          >
+            <b>
+              {{ scope.emptyFilteredText }}
+            </b>
+          </div>
+        </template>
         <template
           :slot="badgedItem"
           slot-scope="row"

--- a/src/components/cdrs/Cdrs.vue
+++ b/src/components/cdrs/Cdrs.vue
@@ -27,6 +27,7 @@
               :locale-data="localeData"
               :time-picker="timePicker"
               :linked-calendars="linkedCalendars"
+              @toggle="toggleIfNotLoading"
               @update="updateValues"
             >
               >
@@ -44,6 +45,7 @@
               size="sm"
               class="ml-2"
               @click="onResetClick"
+              :disabled="loading"
             >
               Reset
             </b-button>
@@ -269,6 +271,11 @@ export default {
     },
     resetCdrFilter() {
       this.$store.dispatch('setCdrFilter', this.filterValue);
+    },
+    toggleIfNotLoading() {
+      if (this.loading) {
+        this.$refs.picker.open = false;
+      }
     },
   },
 };


### PR DESCRIPTION
Now datatable is disabled until data is loaded. The spinner was moved inside the table.
![loading](https://user-images.githubusercontent.com/9091015/69011967-0652bd80-0979-11ea-84c6-4c46b90b207d.png)
If no records found, the user sees the corresponding message
![norecords](https://user-images.githubusercontent.com/9091015/69011968-08b51780-0979-11ea-8693-913ad23f8ce1.png)