### PR TITLE
Table layout bugfix and table cells colouring

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
   },
   "rules": {
     "implicit-arrow-linebreak": "off",
-    "no-param-reassign": ["error", { "props": false }]
+    "no-param-reassign": ["error", { "props": false }],
+    "no-underscore-dangle": ["error", { "allow": ["_cellVariants"] }]
   },
   "globals": {
     "CONFIG": "readonly"

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -5,7 +5,6 @@
       :style="{overflow: hiddenIfLoading}"
       class="dataTable"
     >
-
       <slot
         name="quickFilter"
       />
@@ -18,9 +17,9 @@
       </h6>
 
       <b-progress
+        v-if="loading"
         :value="100"
         :animated="true"
-        v-if="loading"
         variant="secondary"
         class="mt-1"
         height="7px"
@@ -35,12 +34,12 @@
         :fields="fields"
         class="datatable-content"
         show-empty
-        sticky-header="calc(100vh - 12rem)"
+        sticky-header="calc(100vh - 15rem)"
         hover
       >
-
         <template
-          v-slot:empty="scope">
+          v-slot:empty="scope"
+        >
           <div
             class="text-left"
           >
@@ -50,15 +49,15 @@
           </div>
         </template>
         <template
-          :slot="badgedItem"
-          slot-scope="row"
+          v-slot:empty="scope"
         >
-          <b-badge
-            :variant="row.item[badgedItem] ? 'success' : 'danger'"
-            pill
+          <div
+            class="text-left"
           >
-            {{ row.item[badgedItem] }}
-          </b-badge>
+            <b>
+              {{ scope.emptyFilteredText }}
+            </b>
+          </div>
         </template>
       </b-table>
       <b-pagination
@@ -95,10 +94,6 @@ export default {
     rows: {
       type: Number,
       default: 0,
-    },
-    badgedItem: {
-      type: String,
-      default: '',
     },
     getData: {
       type: Function,
@@ -143,10 +138,11 @@ export default {
     right: 15px;
   }
 
-  .datatable-content {
-    display: table;
-    min-width: 100%;
-  }
+  // @todo this code breaks layout of table with large number of entries
+  // .datatable-content {
+  //   display: table;
+  //   min-width: 100%;
+  // }
 
   .pagination {
     padding-left: 15px;

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -5,10 +5,6 @@
       :style="{overflow: hiddenIfLoading}"
       class="dataTable"
     >
-      <<<<<<< HEAD
-      =======
-
-      >>>>>>> changed spinner to progress bar. changed table scroll to browser scroll
       <slot
         name="quickFilter"
       />

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -5,6 +5,10 @@
       :style="{overflow: hiddenIfLoading}"
       class="dataTable"
     >
+      <<<<<<< HEAD
+      =======
+
+      >>>>>>> changed spinner to progress bar. changed table scroll to browser scroll
       <slot
         name="quickFilter"
       />

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -138,18 +138,11 @@ export default {
     right: 15px;
   }
 
-<<<<<<< HEAD
   // @todo this code breaks layout of table with large number of entries
   // .datatable-content {
   //   display: table;
   //   min-width: 100%;
   // }
-=======
-  .datatable-content {
-    display: table;
-    min-width: 100%;
-  }
->>>>>>> changed spinner to progress bar. changed table scroll to browser scroll
 
   .pagination {
     padding-left: 15px;

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -138,11 +138,18 @@ export default {
     right: 15px;
   }
 
+<<<<<<< HEAD
   // @todo this code breaks layout of table with large number of entries
   // .datatable-content {
   //   display: table;
   //   min-width: 100%;
   // }
+=======
+  .datatable-content {
+    display: table;
+    min-width: 100%;
+  }
+>>>>>>> changed spinner to progress bar. changed table scroll to browser scroll
 
   .pagination {
     padding-left: 15px;

--- a/src/components/QuickTableFilter/QuickTableFilter.vue
+++ b/src/components/QuickTableFilter/QuickTableFilter.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="quickfilter-wrapper">
+    <span>use quick filter by Start Time:&nbsp;</span>
+    <date-range-picker
+      ref="picker"
+      v-model="dateRangeModel"
+      :opens="settings.opens"
+      :locale-data="settings.localeData"
+      :time-picker="settings.timePicker"
+      :linked-calendars="settings.linkedCalendars"
+      @toggle="toggleIfNotLoading"
+      @update="updateValues"
+    >
+      >
+      <div
+        slot="input"
+        slot-scope="picker"
+        style="min-width: 250px;"
+      >
+        {{ picker.startDate | date }} - {{ picker.endDate | date }}
+      </div>
+    </date-range-picker>
+    <b-button
+      type="reset"
+      variant="light"
+      size="sm"
+      class="ml-2"
+      :disabled="loading"
+      @click="onResetClick"
+    >
+      Reset
+    </b-button>
+  </div>
+</template>
+
+<script>
+import DateRangePicker from 'vue2-daterange-picker';
+
+import utils from '../../utils';
+
+import 'vue2-daterange-picker/dist/vue2-daterange-picker.css';
+
+export default {
+  name: 'QuickTableFilter',
+  components: {
+    DateRangePicker,
+  },
+  filters: {
+    date(dateStr) {
+      return utils.formatPickerDate(dateStr);
+    },
+  },
+  props: {
+    getData: {
+      type: Function,
+      default() {
+        return [];
+      },
+    },
+    onReset: {
+      type: Function,
+      default() {
+        return undefined;
+      },
+    },
+    dateRange: {
+      type: Object,
+      default() {
+        return {};
+      },
+    },
+    settings: {
+      type: Object,
+      default() {
+        return {
+          opens: 'right',
+          timePicker: true,
+          linkedCalendars: false,
+          localeData: {
+            firstDay: 1,
+            format: 'DD-MM-YYYY HH:mm:ss',
+            applyLabel: 'Filter',
+          },
+        };
+      },
+    },
+  },
+  data() {
+    return {
+      dateRangeModel: this.$props.dateRange,
+    };
+  },
+  computed: {
+    filterValue() {
+      return {
+        timeStartGteq: this.$data.dateRangeModel.startDate,
+        timeStartLteq: this.$data.dateRangeModel.endDate,
+      };
+    },
+    loading() {
+      return this.$store.getters.isRequestPending;
+    },
+  },
+  methods: {
+    updateValues() {
+      this.$store.dispatch('setCdrFilter', this.filterValue);
+      this.$props.getData();
+    },
+    onResetClick() {
+      this.resetCdrFilter();
+      this.$props.getData();
+      this.$props.onReset();
+    },
+    resetCdrFilter() {
+      this.$store.dispatch('setCdrFilter', this.filterValue);
+    },
+    toggleIfNotLoading() {
+      if (this.loading) {
+        this.$refs.picker.open = false;
+      }
+    },
+  },
+};
+</script>
+
+<style>
+.quickfilter {
+  text-align: left;
+  padding: 0 0 10px 15px;
+}
+.quickfilter .form-control {
+  font-size: 0.9rem;
+  text-align: center;
+}
+</style>

--- a/src/components/cdrs/Cdrs.vue
+++ b/src/components/cdrs/Cdrs.vue
@@ -218,11 +218,6 @@ export default {
     onReset() {
       this.$data.dateRange = utils.getLast24Hours();
     },
-    toggleIfNotLoading() {
-      if (this.loading) {
-        this.$refs.picker.open = false;
-      }
-    },
   },
 };
 </script>

--- a/src/components/cdrs/Cdrs.vue
+++ b/src/components/cdrs/Cdrs.vue
@@ -7,7 +7,6 @@
       :fields="fields"
       :items="cdrs"
       :rows="rows"
-      :badged-item="badgedItem"
       :get-data="getCdrs"
     >
       <template v-slot:filter>
@@ -17,38 +16,11 @@
         <div class="quickfilter">
           <div>
             <b-link>Apply custom filters</b-link>, or
-          </div>
-          <div class="quickfilter-wrapper">
-            <span>use quick filter by Start Time:&nbsp;</span>
-            <date-range-picker
-              ref="picker"
-              v-model="dateRange"
-              :opens="opens"
-              :locale-data="localeData"
-              :time-picker="timePicker"
-              :linked-calendars="linkedCalendars"
-              @toggle="toggleIfNotLoading"
-              @update="updateValues"
-            >
-              >
-              <div
-                slot="input"
-                slot-scope="picker"
-                style="min-width: 250px;"
-              >
-                {{ picker.startDate | date }} - {{ picker.endDate | date }}
-              </div>
-            </date-range-picker>
-            <b-button
-              type="reset"
-              variant="light"
-              size="sm"
-              class="ml-2"
-              @click="onResetClick"
-              :disabled="loading"
-            >
-              Reset
-            </b-button>
+            <QuickTableFilter
+              :get-data="getCdrs"
+              :on-reset="onReset"
+              :date-range="dateRange"
+            />
           </div>
         </div>
       </template>
@@ -57,11 +29,11 @@
 </template>
 
 <script>
-import { isEmpty } from 'lodash';
-import DateRangePicker from 'vue2-daterange-picker';
+import { isEmpty, flow } from 'lodash';
 
 import utils from '../../utils';
 import DataTable from '../DataTable/DataTable';
+import QuickTableFilter from '../QuickTableFilter/QuickTableFilter';
 
 import 'vue2-daterange-picker/dist/vue2-daterange-picker.css';
 
@@ -70,26 +42,12 @@ export default {
   components: {
     // CdrFilter,
     DataTable,
-    DateRangePicker,
+    QuickTableFilter,
   },
-  filters: {
-    date(dateStr) {
-      return utils.formatPickerDate(dateStr);
-    },
-  },
+
   data() {
     return {
-      badgedItem: 'success',
-      // Picker stuff
-      opens: 'right',
-      timePicker: true,
       dateRange: utils.getLast24Hours(),
-      linkedCalendars: false,
-      localeData: {
-        firstDay: 1,
-        format: 'DD-MM-YYYY HH:mm:ss',
-        applyLabel: 'Filter',
-      },
       // Table fields
       fields: [
         {
@@ -234,16 +192,13 @@ export default {
   },
   computed: {
     cdrs() {
-      return this.$store.getters.cdrs.items;
+      return flow(utils.formatCdrs, utils.colorCdrsTable)(this.$store.getters.cdrs.items);
     },
     filterValue() {
       return {
         timeStartGteq: this.$data.dateRange.startDate,
         timeStartLteq: this.$data.dateRange.endDate,
       };
-    },
-    loading() {
-      return this.$store.getters.isRequestPending;
     },
     rows() {
       return this.$store.getters.cdrs && this.$store.getters.cdrs.meta
@@ -260,17 +215,8 @@ export default {
     getCdrs(pageNumber) {
       this.$store.dispatch('getCdrs', pageNumber);
     },
-    updateValues() {
-      this.$store.dispatch('setCdrFilter', this.filterValue);
-      this.getCdrs();
-    },
-    onResetClick() {
+    onReset() {
       this.$data.dateRange = utils.getLast24Hours();
-      this.resetCdrFilter();
-      this.getCdrs();
-    },
-    resetCdrFilter() {
-      this.$store.dispatch('setCdrFilter', this.filterValue);
     },
     toggleIfNotLoading() {
       if (this.loading) {
@@ -282,12 +228,4 @@ export default {
 </script>
 
 <style>
-.quickfilter {
-  text-align: left;
-  padding: 0 0 10px 15px;
-}
-.quickfilter .form-control {
-  font-size: 0.9rem;
-  text-align: center;
-}
 </style>

--- a/src/components/rates/Rates.vue
+++ b/src/components/rates/Rates.vue
@@ -7,7 +7,6 @@
       :fields="fields"
       :items="rates"
       :rows="rows"
-      :badged-item="badgedItem"
       :get-data="getRates"
     >
       <template v-slot:filter>
@@ -18,8 +17,10 @@
 </template>
 
 <script>
+import { flow } from 'lodash';
 // import RatesFilter from './RatesFilter';
 import DataTable from '../DataTable/DataTable';
+import utils from '../../utils';
 
 export default {
   name: 'Rates',
@@ -29,7 +30,6 @@ export default {
   },
   data() {
     return {
-      badgedItem: 'rejectCalls',
       fields: [
         {
           key: 'connect-fee',
@@ -76,7 +76,7 @@ export default {
   },
   computed: {
     rates() {
-      return this.$store.getters.rates.items;
+      return flow(utils.formatRates)(this.$store.getters.rates.items);
     },
     rows() {
       return this.$store.getters.rates && this.$store.getters.rates.meta

--- a/src/store/modules/cdrs.js
+++ b/src/store/modules/cdrs.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line
 import { jsonApi } from '../../api';
 import { RESOURCES } from '../../static/constants/api';
-import utils from '../../utils';
 
 const state = {
   cdrs: {},
@@ -11,7 +10,7 @@ const state = {
 };
 const getters = {
   cdrs: (currentState) => ({
-    items: utils.normalizeCdrs(currentState.cdrs.data), meta: currentState.cdrs.meta,
+    items: currentState.cdrs.data, meta: currentState.cdrs.meta,
   }),
   isRequestPending: (currentState) => currentState.requestPending,
   cdrFilter: (currentState) => currentState.cdrFilter,

--- a/src/store/modules/rates.js
+++ b/src/store/modules/rates.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line
 import { jsonApi } from '../../api';
 import { RESOURCES } from '../../static/constants/api';
-import utils from '../../utils';
 
 const state = {
   rates: {},
@@ -9,7 +8,7 @@ const state = {
 };
 const getters = {
   rates: (currentState) => ({
-    items: utils.normalizeRates(currentState.rates.data),
+    items: currentState.rates.data,
     meta: currentState.rates.meta,
   }),
   rateFilter: (currentState) => currentState.rateFilter,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,9 @@
 import * as date from './date/date';
 import * as response from './normalizers/response';
+import tableDataNormalizers from './tableDataNormalizers/index';
 
 export default {
   ...date,
   ...response,
+  ...tableDataNormalizers,
 };

--- a/src/utils/normalizers/response.js
+++ b/src/utils/normalizers/response.js
@@ -1,16 +1,4 @@
-import { formatTableDate } from '../date/date';
-
-export const normalizeCdrs = (cdrs = []) =>
-  cdrs.map((item) => {
-    item['time-start'] = formatTableDate(item['time-start']);
-    item['time-connect'] = formatTableDate(item['time-connect']);
-    item['time-end'] = formatTableDate(item['time-end']);
-    return item;
-  });
-
-export const normalizeRates = (rates = []) =>
-  rates.map((item) => ({
-    ...item,
-    'valid-from': formatTableDate(item['valid-from']),
-    'valid-till': formatTableDate(item['valid-till']),
-  }));
+// If any data transformation will be applied globally to all data, after it is fetched -
+// helper for this transformation need to be placed here
+// Because at the time of writing all transformations are applied only to tables - they
+// were put to tableDataTransformations

--- a/src/utils/tableDataNormalizers/cdrs.js
+++ b/src/utils/tableDataNormalizers/cdrs.js
@@ -1,0 +1,22 @@
+import { formatTableDate } from '../date/date';
+
+export const formatCdrs = (cdrs = []) =>
+  cdrs.map((item) => {
+    item['time-start'] = formatTableDate(item['time-start']);
+    item['time-connect'] = formatTableDate(item['time-connect']);
+    item['time-end'] = formatTableDate(item['time-end']);
+    item.success = item.success ? 'Yes' : 'No';
+
+    return item;
+  });
+
+export const colorCdrsTable = (cdrs = []) =>
+  cdrs.map((item) => {
+    item._cellVariants = {};
+
+    if (item.success === 'No') {
+      item._cellVariants.success = 'danger';
+    }
+
+    return item;
+  });

--- a/src/utils/tableDataNormalizers/index.js
+++ b/src/utils/tableDataNormalizers/index.js
@@ -1,0 +1,4 @@
+import * as cdrs from './cdrs';
+import * as rates from './rates';
+
+export default { ...cdrs, ...rates };

--- a/src/utils/tableDataNormalizers/rates.js
+++ b/src/utils/tableDataNormalizers/rates.js
@@ -1,0 +1,10 @@
+import { formatTableDate } from '../date/date';
+
+// eslint-disable-next-line
+export const formatRates = (rates = []) =>
+  rates.map((item) => {
+    item['valid-from'] = formatTableDate(item['valid-from']);
+    item['valid-till'] = formatTableDate(item['valid-till']);
+
+    return item;
+  });


### PR DESCRIPTION
1. Fixed bug with statistics pages layout, caused by applying `display: table` to them.
2. Data transformation for tables was excluded to helpers and made in more generic way.
3. Colorization of data in table done in bootstrap-vue compliant way with built-in colors.
4. Badges-based colorization removed.
5. Quick filter component excluded to separate folder.
![colors](https://user-images.githubusercontent.com/15054302/71484305-15484d80-280c-11ea-9dee-018a574b06f4.gif)