### PR TITLE
Small fixes for UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,9 @@
 
 <script>
 import NavBar from './components/NavBar/NavBar';
-import { AUTH, NOTIFICATION_TYPES, GENERAL_ROUTE_NAMES } from './constants';
+import {
+  AUTH, NOTIFICATION_TYPES, GENERAL_ROUTE_NAMES, NETWORK_SERVICE,
+} from './constants';
 import { jsonApi } from './api';
 
 export default {
@@ -51,6 +53,8 @@ export default {
           this.$store.dispatch(AUTH.ACTIONS.LOGOUT);
           this.$router.push('/login');
         }
+
+        this.$store.dispatch(NETWORK_SERVICE.ACTIONS.SWITCH_PENDING_STATE, false);
 
         return payload;
       },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -66,8 +66,6 @@ export class JsonApi {
   setToken = (token) => {
     this.instance.headers.Authorization = `Bearer ${token}`;
   };
-
-  createResource = (resourceName, data) => this.instance.create(resourceName, data)
 }
 
 export const jsonApi = new JsonApi();

--- a/src/components/ActiveCallsChart/ActiveCallsChart.vue
+++ b/src/components/ActiveCallsChart/ActiveCallsChart.vue
@@ -60,7 +60,6 @@ export default {
         });
       }
 
-
       return chartData;
     },
   },

--- a/src/components/ActiveCallsChart/fixtures.js
+++ b/src/components/ActiveCallsChart/fixtures.js
@@ -13,7 +13,6 @@ export const CHART_OPTIONS = {
     xAxes: [{
       type: 'time',
       position: 'bottom',
-      // bounds: 'ticks',
       ticks: {
         major: {
           enabled: true,
@@ -23,11 +22,12 @@ export const CHART_OPTIONS = {
       },
       time: {
         displayFormats: {
+          minute: 'HH:mm',
           hour: 'HH:mm',
           day: 'MM-DD-YY HH:mm',
         },
-        // round: true,
-        minUnit: 'hour',
+        round: true,
+        stepSize: 1,
       },
       scaleLabel: {
         display: true,
@@ -52,11 +52,13 @@ export const CHART_OPTIONS = {
     enabled: true,
     threshold: 300, // change this
 
-    auto: false,
+    auto: true,
     onInit: true,
-
-    preferOriginalData: true,
-    restoreOriginalData: false,
+  },
+  tooltips: {
+    intersect: false,
+    mode: 'index',
+    position: 'nearest',
   },
 };
 

--- a/src/components/ViewFilters/components/TimeRangeFilter/TimeRangeFilter.vue
+++ b/src/components/ViewFilters/components/TimeRangeFilter/TimeRangeFilter.vue
@@ -8,6 +8,7 @@
       :locale-data="settings.localeData"
       :time-picker="settings.timePicker"
       :auto-apply="settings.autoApply"
+      :date-util="settings.dateUtil"
       :linked-calendars="settings.linkedCalendars"
       @toggle="toggleIfNotLoading"
       @update="updateValues"
@@ -35,7 +36,7 @@
 </template>
 
 <script>
-import DateRangePicker from 'vue2-daterange-picker';
+import DateRangePicker from 'vue2-daterange-picker/src';
 
 import utils from '../../../../utils';
 import { TIME_RANGE_FILTER } from '../../../../constants';
@@ -60,6 +61,7 @@ export default {
           opens: 'left',
           timePicker: true,
           linkedCalendars: false,
+          dateUtil: 'moment',
           localeData: {
             firstDay: 1,
             format: 'DD-MM-YYYY HH:mm:ss',

--- a/src/store/modules/networkServices.js
+++ b/src/store/modules/networkServices.js
@@ -9,7 +9,11 @@ const getters = {
   requestIsPending: (currentState) => Boolean(currentState.requestIsPending),
 };
 
-const actions = {};
+const actions = {
+  [NETWORK_SERVICE.ACTIONS.SWITCH_PENDING_STATE]: ({ commit }, pendingStatus) => {
+    commit(NETWORK_SERVICE.MUTATIONS.SWITCH_PENDING_STATE, pendingStatus);
+  },
+};
 
 const mutations = {
   [NETWORK_SERVICE.MUTATIONS.SWITCH_PENDING_STATE]: (currentState, requestIsPending) => {


### PR DESCRIPTION
1. Time format for time filter footer adjusted to show proper values.
Before:
<img width="487" alt="image" src="https://user-images.githubusercontent.com/15054302/79109724-357b2880-7d79-11ea-8d54-f932b4e2a15b.png">
After:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/15054302/79109205-29db3200-7d78-11ea-81dc-f7efbbd945f9.png">

2. Removed restrictions for axis X labels, previously applied for very small time ranges:
Before:
<img width="954" alt="image" src="https://user-images.githubusercontent.com/15054302/79109760-462b9e80-7d79-11ea-8f52-e8834110a820.png">
After: 
<img width="969" alt="image" src="https://user-images.githubusercontent.com/15054302/79109385-89d1d880-7d78-11ea-95be-ee8f24e9b40c.png">

3. Applied proper handling of tooltips. Now they are appearing on whole chart hover, not on particular point.
Before:

![yeti-tooltip-before](https://user-images.githubusercontent.com/15054302/79109976-c4884080-7d79-11ea-9448-36c50620d222.gif)
After:

![yeti-tooltip-after](https://user-images.githubusercontent.com/15054302/79109937-af131680-7d79-11ea-9bfe-c5a6626ee216.gif)

4. Pending request state is handled correctly after auth error occures. Previously it tended to stuck and block UI.
Before:

![pending-before](https://user-images.githubusercontent.com/15054302/79111551-036bc580-7d7d-11ea-8590-cbef62b0f8d2.gif)
After:

![pending-after](https://user-images.githubusercontent.com/15054302/79111538-fb138a80-7d7c-11ea-82bf-c45d2dc168a7.gif)