### PR TITLE
Rates order adjusted

### DIFF
--- a/src/components/rates/constants.js
+++ b/src/components/rates/constants.js
@@ -1,35 +1,27 @@
 export const TABLE_HEADERS = [
   {
-    key: 'connect-fee',
-    label: 'Connect fee',
-  },
-  {
-    key: 'initial-interval',
-    label: 'Initial interval',
-  },
-  {
-    key: 'initial-rate',
-    label: 'Initial rate',
-  },
-  {
-    key: 'network-prefix',
-    label: 'Network prefix',
-  },
-  {
-    key: 'next-interval',
-    label: 'Next interval',
-  },
-  {
-    key: 'next-rate',
-    label: 'Next rate',
-  },
-  {
     key: 'prefix',
     label: 'Prefix',
   },
   {
     key: 'reject-calls',
     label: 'Reject calls',
+  },
+  {
+    key: 'billing-interval',
+    label: 'Billing interval',
+  },
+  {
+    key: 'rate',
+    label: 'Rate',
+  },
+  {
+    key: 'connect-fee',
+    label: 'Connect fee',
+  },
+  {
+    key: 'network-prefix',
+    label: 'Network prefix',
   },
   {
     key: 'valid-from',

--- a/src/utils/tableDataNormalizers/rates.js
+++ b/src/utils/tableDataNormalizers/rates.js
@@ -5,5 +5,11 @@ export const formatRates = (rates = []) =>
     item['valid-from'] = formatTableDate(item['valid-from']);
     item['valid-till'] = formatTableDate(item['valid-till']);
 
+    item['billing-intervals'] = `${item['initial-interval']}/${
+      item['next-interval']
+    }`;
+
+    item.rate = `${item['initial-rate']}/${item['next-rate']}`;
+
     return item;
   });


### PR DESCRIPTION
According to an issue https://github.com/yeti-switch/yeti-client/issues/31 fields order in Rates table was changed.
Result:
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/15054302/79639034-3bae4200-8189-11ea-9006-a1f45d6cee7c.png">