### PR TITLE
Small fixes in UI

### DIFF
--- a/src/components/ViewFilters/components/TimeRangeFilter/TimeRangeFilter.vue
+++ b/src/components/ViewFilters/components/TimeRangeFilter/TimeRangeFilter.vue
@@ -51,7 +51,7 @@ export default {
   },
   filters: {
     date(dateStr) {
-      return utils.formatDateFromString(dateStr);
+      return utils.formatDateFromObject(dateStr);
     },
   },
   props: {

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -83,7 +83,9 @@ export const RELATIONSHIPS = {
     'local-tag': '',
     'auth-orig-transport-protocol': {
       jsonApi: 'hasMany',
-      type: 'comments',
+    },
+    account: {
+      jsonApi: 'hasOne',
     },
     // These fields are not used in the table
     'diversion-in': '',

--- a/src/pages/Rates/Rates.vue
+++ b/src/pages/Rates/Rates.vue
@@ -4,6 +4,7 @@
     :items="rates"
     :rows="rows"
     :get-data="getRates"
+    :items-to-badge="itemsToBadge"
   />
 </template>
 
@@ -24,6 +25,10 @@ export default {
   data() {
     return {
       fields: TABLE_HEADERS,
+      itemsToBadge: [{
+        id: 'reject-calls',
+        errorValue: false,
+      }],
     };
   },
   computed: {

--- a/src/utils/tableDataNormalizers/cdrs.js
+++ b/src/utils/tableDataNormalizers/cdrs.js
@@ -1,4 +1,5 @@
 import { formatDateFromString } from '../date/date';
+import { prettifyNullValue } from './common';
 
 export const formatCdrs = (cdrs = []) =>
   cdrs.map((item) => {
@@ -7,8 +8,8 @@ export const formatCdrs = (cdrs = []) =>
     item['time-end'] = formatDateFromString(item['time-end']);
     item.success = item.success ? 'Yes' : 'No';
     item['disconnect-full-info'] = `${item['lega-disconnect-code']} ${item['lega-disconnect-reason']}`;
-    item.rate = `${item['destination-initial-rate']}/${item['destination-next-rate']}`;
-    item['billing-intervals'] = `${item['destination-initial-interval']}/${item['destination-next-interval']}`;
+    item.rate = `${prettifyNullValue(item['destination-initial-rate'])}/${prettifyNullValue(item['destination-next-rate'])}`;
+    item['billing-intervals'] = `${prettifyNullValue(item['destination-initial-interval'])}/${prettifyNullValue(item['destination-next-interval'])}`;
     item['originator-address'] = `${item['auth-orig-ip']}:${item['auth-orig-port']}`;
 
     return item;

--- a/src/utils/tableDataNormalizers/common.js
+++ b/src/utils/tableDataNormalizers/common.js
@@ -1,0 +1,1 @@
+export const prettifyNullValue = (value) => (value === null ? ' - ' : value);

--- a/src/utils/tableDataNormalizers/rates.js
+++ b/src/utils/tableDataNormalizers/rates.js
@@ -1,4 +1,5 @@
 import { formatDateFromString } from '../date/date';
+import { prettifyNullValue } from './common';
 
 export const formatRates = (rates = []) =>
   rates.map((item) => {
@@ -9,7 +10,7 @@ export const formatRates = (rates = []) =>
       item['next-interval']
     }`;
 
-    item.rate = `${item['initial-rate']}/${item['next-rate']}`;
+    item.rate = `${prettifyNullValue(item['initial-rate'])}/${prettifyNullValue(item['next-rate'])}`;
 
     return item;
   });

--- a/src/utils/tableDataNormalizers/tests/common.test.js
+++ b/src/utils/tableDataNormalizers/tests/common.test.js
@@ -1,0 +1,13 @@
+import * as common from '../common';
+
+describe('prettifyRateValue store helper', () => {
+  it('formats rates field if it is null', () => {
+    const result = common.prettifyNullValue(null);
+    expect(result).toBe(' - ');
+  });
+
+  it('do not format rates field if it has correct value', () => {
+    const result = common.prettifyNullValue(1);
+    expect(result).toBe(1);
+  });
+});


### PR DESCRIPTION
1. Added proper handling of null values in crds table.
<img width="544" alt="image" src="https://user-images.githubusercontent.com/15054302/82464221-1d0bd580-9abe-11ea-9049-e1a39840cc38.png">
2. Added badge in rates table
<img width="216" alt="image" src="https://user-images.githubusercontent.com/15054302/82464288-3280ff80-9abe-11ea-9d06-02fe255f3aec.png">
3. Fixed issue with empty value in time filter (was broken in previous PR)
<img width="487" alt="image" src="https://user-images.githubusercontent.com/15054302/82464371-4b89b080-9abe-11ea-91f1-fec503a9d1a1.png">
4. Added `account` field to description of `cdrs` resource, to suppress Devour warnings.