### PR TITLE
move some cdr fields to expandable section

### DIFF
--- a/src/components/DataTableAnt/DataTableAnt.vue
+++ b/src/components/DataTableAnt/DataTableAnt.vue
@@ -31,7 +31,6 @@
       <a-table
         :columns="fields.filter(field => field.showInHeader)"
         :data-source="items"
-        :scroll="{ x: true, y: 700 }"
         :pagination="{ pageSize: 50, total: rows, hideOnSinglePage: true }"
         :loading="requestIsPending"
         @change="onPaginationChange"
@@ -165,7 +164,10 @@ export default {
         vertical-align: .125em;
       }
     }
-
   }
+  .ant-table-body {
+    background-color: #ffffff;
+  }
+
 }
 </style>

--- a/src/components/DataTableAnt/DataTableAnt.vue
+++ b/src/components/DataTableAnt/DataTableAnt.vue
@@ -29,7 +29,7 @@
         </a-col>
       </a-row>
       <a-table
-        :columns="fields"
+        :columns="fields.filter(field => field.showInHeader)"
         :data-source="items"
         :scroll="{ x: true, y: 700 }"
         :pagination="{ pageSize: 50, total: rows, hideOnSinglePage: true }"
@@ -47,6 +47,20 @@
             {{ badge }}
           </a-tag>
         </span>
+        <template
+          v-if="expandable"
+          v-slot:expandedRowRender="record"
+        >
+          <a-descriptions>
+            <a-descriptions-item
+              v-for="(field) of fields"
+              :key="field"
+              :label="field.title"
+            >
+              {{ record[field.key] }}
+            </a-descriptions-item>
+          </a-descriptions>
+        </template>
       </a-table>
     </div>
   </div>
@@ -94,6 +108,12 @@ export default {
       type: Function,
       default() {
         return [];
+      },
+    },
+    expandable: {
+      type: Boolean,
+      default() {
+        return false;
       },
     },
   },

--- a/src/components/DataTableAnt/DataTableAnt.vue
+++ b/src/components/DataTableAnt/DataTableAnt.vue
@@ -159,7 +159,7 @@ export default {
 .ant-table-wrapper {
   .ant-table-pagination {
     &.ant-pagination {
-      float: initial;
+      float: left;
 
       .anticon {
         vertical-align: .125em;

--- a/src/components/DataTableAnt/tests/DataTableAnt.test.js
+++ b/src/components/DataTableAnt/tests/DataTableAnt.test.js
@@ -38,11 +38,13 @@ describe('DataTableAnt', () => {
           key: 'name',
           dataIndex: 'name',
           title: 'Name',
+          showInHeader: true,
         },
         {
           key: 'surname',
           dataIndex: 'surname',
           title: 'Surname',
+          showInHeader: true,
         },
       ],
       items: [
@@ -90,16 +92,19 @@ describe('DataTableAnt', () => {
           key: 'name',
           dataIndex: 'name',
           title: 'Name',
+          showInHeader: true,
         },
         {
           key: 'surname',
           dataIndex: 'surname',
           title: 'Surname',
+          showInHeader: true,
         },
         {
           key: 'is-admin',
           dataIndex: 'is-admin',
           title: 'Is admin',
+          showInHeader: true,
           scopedSlots: {
             customRender: 'badge',
           },

--- a/src/pages/Cdrs/Cdrs.vue
+++ b/src/pages/Cdrs/Cdrs.vue
@@ -4,6 +4,7 @@
     :items="formattedCdrs"
     :rows="rows"
     :get-data="getCdrs"
+    expandable
   />
 </template>
 

--- a/src/pages/Cdrs/constants.js
+++ b/src/pages/Cdrs/constants.js
@@ -6,16 +6,6 @@ export const TABLE_HEADERS_ANT = [
     showInHeader: true,
   },
   {
-    key: 'time-connect',
-    dataIndex: 'time-connect',
-    width: 200,
-  },
-  {
-    key: 'time-end',
-    dataIndex: 'time-end',
-    width: 200,
-  },
-  {
     key: 'duration',
     dataIndex: 'duration',
     width: 200,
@@ -31,6 +21,11 @@ export const TABLE_HEADERS_ANT = [
     },
   },
   {
+    key: 'time-connect',
+    dataIndex: 'time-connect',
+    width: 200,
+  },
+  {
     key: 'src-name-in',
     dataIndex: 'src-name-in',
     width: 200,
@@ -38,6 +33,11 @@ export const TABLE_HEADERS_ANT = [
   {
     key: 'src-prefix-in',
     dataIndex: 'src-prefix-in',
+    width: 200,
+  },
+  {
+    key: 'time-end',
+    dataIndex: 'time-end',
     width: 200,
   },
   {

--- a/src/pages/Cdrs/constants.js
+++ b/src/pages/Cdrs/constants.js
@@ -3,6 +3,7 @@ export const TABLE_HEADERS_ANT = [
     key: 'time-start',
     dataIndex: 'time-start',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'time-connect',
@@ -18,11 +19,13 @@ export const TABLE_HEADERS_ANT = [
     key: 'duration',
     dataIndex: 'duration',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'success',
     dataIndex: 'success',
     width: 200,
+    showInHeader: true,
     scopedSlots: {
       customRender: 'badge',
     },
@@ -46,6 +49,7 @@ export const TABLE_HEADERS_ANT = [
     key: 'dst-prefix-in',
     dataIndex: 'dst-prefix-in',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'dst-prefix-routing',
@@ -76,6 +80,7 @@ export const TABLE_HEADERS_ANT = [
     key: 'customer-price',
     dataIndex: 'customer-price',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'originator-address',

--- a/src/pages/Networks/constants.js
+++ b/src/pages/Networks/constants.js
@@ -3,6 +3,7 @@ export const TABLE_HEADERS_ANT = [
     key: 'name',
     dataIndex: 'name',
     width: 300,
+    showInHeader: true,
     customRender(name, row) {
       return <a
       router-link
@@ -16,10 +17,12 @@ export const TABLE_HEADERS_ANT = [
     key: 'network-type',
     dataIndex: 'network-type',
     width: 300,
+    showInHeader: true,
   },
   {
     key: 'id',
     dataIndex: 'id',
     width: 300,
+    showInHeader: true,
   },
 ];

--- a/src/pages/Rates/constants.js
+++ b/src/pages/Rates/constants.js
@@ -3,11 +3,13 @@ export const TABLE_HEADERS_ANT = [
     key: 'prefix',
     dataIndex: 'prefix',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'reject-calls',
     dataIndex: 'reject-calls',
     width: 200,
+    showInHeader: true,
     scopedSlots: {
       customRender: 'badge',
     },
@@ -16,30 +18,36 @@ export const TABLE_HEADERS_ANT = [
     key: 'billing-interval',
     dataIndex: 'billing-interval',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'rate',
     dataIndex: 'rate',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'connect-fee',
     dataIndex: 'connect-fee',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'network-prefix',
     dataIndex: 'network-prefix',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'valid-from',
     dataIndex: 'valid-from',
     width: 200,
+    showInHeader: true,
   },
   {
     key: 'valid-till',
     dataIndex: 'valid-till',
     width: 200,
+    showInHeader: true,
   },
 ];


### PR DESCRIPTION
CDR table can not be fully displayed without the scrolls. 
This PR adds expandable attribute to Data Table component which allows make table entries expandable and display full information.
Also pagination component moved to the left.

Before:
![image](https://user-images.githubusercontent.com/9091015/93002437-c7ad7580-f53f-11ea-8290-b15d400da25b.png)


After:
![image](https://user-images.githubusercontent.com/9091015/93002474-03e0d600-f540-11ea-8298-60ab85092749.png)
